### PR TITLE
synthesised sound fix

### DIFF
--- a/psychopy_sounddevice/backend_sounddevice.py
+++ b/psychopy_sounddevice/backend_sounddevice.py
@@ -259,6 +259,7 @@ class SoundDeviceSound(_SoundBase):
     """
 
     def __init__(self, value="C", secs=0.5, octave=4, stereo=-1,
+                 speaker=None,
                  volume=1.0, loops=0,
                  sampleRate=None, blockSize=128,
                  preBuffer=-1,
@@ -292,6 +293,7 @@ class SoundDeviceSound(_SoundBase):
         :param autoLog: whether to automatically log every change
         """
         self.sound = value
+        self.speaker = speaker
         self.name = name
         self.secs = secs  # for any synthesised sounds (notesand freqs)
         self.octave = octave  # for note name sounds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,6 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 where = ["",]
+
+[project.entry-points."psychopy.sound"]
+backend_sounddevice = "psychopy_sounddevice.backend_sounddevice"


### PR DESCRIPTION
I based this patch off @TEParsons main branch: https://github.com/TEParsons/psychopy-sounddevice
Needed to make these changes to have code like this working, this now gives a similar behavior to PTB(can now actually hear the sound play):
```
beep = sound.Sound(440, secs=2.0, volume=0.8)
beep.play()
```
Having this change will allow me to use psychopy 2025.1.1 natively on macos arm with sound support.